### PR TITLE
Proposed fix for issues 12 and 7

### DIFF
--- a/R/cannedEstimationFunctions.R
+++ b/R/cannedEstimationFunctions.R
@@ -87,17 +87,29 @@ random.effect <- function(dat, incl.period.effect, outcome.type, alpha) {
 		offsets <- rep(0, nrow(dat))
 	}
 
-	if(incl.period.effect==0){
-		fit <- glmer(y ~ trt + (1|clust),
-			     data=dat,
-			     family=outcome.type,
-			     offset=offsets)
-	} else {
-		fit <- glmer(y ~ trt + per + (1|clust) - 1,
-			     data=dat,
-			     family=outcome.type,
-			     offset=offsets)
-	}
+  if(incl.period.effect==0){
+    if(outcome.type=="gaussian"){
+      fit <- lmer(y ~ trt + (1|clust),
+                  data=dat,
+                  offset=offsets)
+    }
+    else {
+      fit <- glmer(y ~ trt + (1|clust),
+                   data=dat,
+                   family=outcome.type,
+                   offset=offsets)
+    }} else {
+      if(outcome.type=="gaussian"){
+        fit <- lmer(y ~ trt + per + (1|clust) - 1,
+                    data=dat,
+                    offset=offsets)
+      }
+      else{
+        fit <- glmer(y ~ trt + per + (1|clust) - 1,
+                     data=dat,
+                     family=outcome.type,
+                     offset=offsets)
+      }}
 
 	n.clust <- length(unique(dat$clust))
 	df <- n.clust - 2 ## based on k-2 in Donner & Klar p.118


### PR DESCRIPTION
Issues #12 and #7 both refer to the warning to call lmer directly (that basically spams the console when certain functions are performed); to fix it, I changed the code to include an if statement that checks if the family is gaussian and if so, the code calls lmer instead of glmer. This change has resolved the issue on my end, with the caveat that I only use power.sim.normal.